### PR TITLE
feat: Add VerticalScrollbarIfSupported component

### DIFF
--- a/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.android.kt
+++ b/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.android.kt
@@ -4,9 +4,10 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) = Unit
+actual fun PlatformVerticalScrollbar(scrollState: ScrollState, modifier: Modifier) = Unit
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) = Unit
+actual fun PlatformVerticalScrollbar(scrollState: LazyGridState, modifier: Modifier) = Unit

--- a/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.android.kt
+++ b/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.android.kt
@@ -1,0 +1,12 @@
+package io.aoriani.ecomm.ui.screens.common.components
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) = Unit
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) = Unit

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/navigation/Navigation.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/navigation/Navigation.kt
@@ -2,7 +2,6 @@ package io.aoriani.ecomm.ui.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/cart/CartScreen.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/cart/CartScreen.kt
@@ -1,8 +1,5 @@
 package io.aoriani.ecomm.ui.screens.cart
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -11,15 +8,10 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import ecommerceapp.composeapp.generated.resources.Res
 import ecommerceapp.composeapp.generated.resources.cart_title
 import ecommerceapp.composeapp.generated.resources.content_description_back
-import ecommerceapp.composeapp.generated.resources.product_list_title
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.kt
@@ -2,11 +2,24 @@ package io.aoriani.ecomm.ui.screens.common.components
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 
 @Composable
-expect fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState)
+fun BoxScope.VerticalScrollbarIfSupported(scrollState: ScrollState, modifier: Modifier = Modifier) {
+    PlatformVerticalScrollbar(scrollState, modifier.align(Alignment.CenterEnd).fillMaxHeight())
+}
 
 @Composable
-expect fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState)
+fun BoxScope.VerticalScrollbarIfSupported(scrollState: LazyGridState, modifier: Modifier = Modifier) {
+    PlatformVerticalScrollbar(scrollState, modifier.align(Alignment.CenterEnd).fillMaxHeight())
+}
+
+@Composable
+expect fun PlatformVerticalScrollbar(scrollState: ScrollState, modifier: Modifier = Modifier)
+
+@Composable
+expect fun PlatformVerticalScrollbar(scrollState: LazyGridState, modifier: Modifier = Modifier)

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.kt
@@ -1,0 +1,12 @@
+package io.aoriani.ecomm.ui.screens.common.components
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState)
+
+@Composable
+expect fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState)

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsScreen.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsScreen.kt
@@ -1,6 +1,8 @@
 package io.aoriani.ecomm.ui.screens.productdetails
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -18,6 +20,7 @@ import androidx.compose.ui.Modifier
 import ecommerceapp.composeapp.generated.resources.Res
 import ecommerceapp.composeapp.generated.resources.content_description_back
 import io.aoriani.ecomm.data.model.Product
+import io.aoriani.ecomm.ui.screens.common.components.VerticalScrollBarIfSupported
 import io.aoriani.ecomm.ui.screens.productdetails.components.ProductImage
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
@@ -45,21 +48,25 @@ fun ProductDetailsScreen(
             )
         }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .verticalScroll(rememberScrollState())
-        ) {
-            ProductImage(
-                //TODO: Handle missing image better
-                imageUrl = state.imageUrl.orEmpty(),
-                contentDescription = state.title,
-                modifier = Modifier.fillMaxWidth()
-            )
-            if (state is ProductDetailsUiState.Loaded) {
-                Text(text = state.product.name)
-                Text(text = state.product.description)
+        Box(modifier = Modifier.padding(paddingValues)) {
+            val scrollState = rememberScrollState()
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+            ) {
+                ProductImage(
+                    //TODO: Handle missing image better
+                    imageUrl = state.imageUrl.orEmpty(),
+                    contentDescription = state.title,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                if (state is ProductDetailsUiState.Loaded) {
+                    Text(text = state.product.name)
+                    Text(text = state.product.description)
+                }
             }
+            VerticalScrollBarIfSupported(scrollState)
         }
     }
 }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsScreen.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import ecommerceapp.composeapp.generated.resources.Res
 import ecommerceapp.composeapp.generated.resources.content_description_back
 import io.aoriani.ecomm.data.model.Product
-import io.aoriani.ecomm.ui.screens.common.components.VerticalScrollBarIfSupported
+import io.aoriani.ecomm.ui.screens.common.components.VerticalScrollbarIfSupported
 import io.aoriani.ecomm.ui.screens.productdetails.components.ProductImage
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
@@ -66,7 +66,7 @@ fun ProductDetailsScreen(
                     Text(text = state.product.description)
                 }
             }
-            VerticalScrollBarIfSupported(scrollState)
+            VerticalScrollbarIfSupported(scrollState)
         }
     }
 }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListScreen.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -24,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import ecommerceapp.composeapp.generated.resources.Res
 import ecommerceapp.composeapp.generated.resources.product_list_title
 import io.aoriani.ecomm.data.model.ProductPreview
-import io.aoriani.ecomm.ui.screens.common.components.VerticalScrollBarIfSupported
+import io.aoriani.ecomm.ui.screens.common.components.VerticalScrollbarIfSupported
 import io.aoriani.ecomm.ui.screens.productlist.components.LoadingOverlay
 import io.aoriani.ecomm.ui.screens.productlist.components.ProductTile
 import org.jetbrains.compose.resources.stringResource
@@ -67,7 +66,7 @@ fun ProductListScreen(
                                     onClick = { navigateToProductDetails(item) })
                             }
                         }
-                        VerticalScrollBarIfSupported(scrollState)
+                        VerticalScrollbarIfSupported(scrollState)
                     }
                 }
             }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListScreen.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListScreen.kt
@@ -1,11 +1,14 @@
 package io.aoriani.ecomm.ui.screens.productlist
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -21,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import ecommerceapp.composeapp.generated.resources.Res
 import ecommerceapp.composeapp.generated.resources.product_list_title
 import io.aoriani.ecomm.data.model.ProductPreview
+import io.aoriani.ecomm.ui.screens.common.components.VerticalScrollBarIfSupported
 import io.aoriani.ecomm.ui.screens.productlist.components.LoadingOverlay
 import io.aoriani.ecomm.ui.screens.productlist.components.ProductTile
 import org.jetbrains.compose.resources.stringResource
@@ -50,15 +54,20 @@ fun ProductListScreen(
                 modifier = Modifier.padding(paddingValues)
             ) {
                 if (state is ProductListUiState.Success) {
-                    LazyVerticalGrid(
-                        columns = GridCells.Adaptive(minSize = 150.dp),
-                        modifier = Modifier.fillMaxSize().background(Color(0xFFEEEEEE))
-                    ) {
-                        items(state.products) { item ->
-                            ProductTile(
-                                product = item,
-                                onClick = { navigateToProductDetails(item) })
+                    val scrollState = rememberLazyGridState()
+                    Box {
+                        LazyVerticalGrid(
+                            columns = GridCells.Adaptive(minSize = 150.dp),
+                            state = scrollState,
+                            modifier = Modifier.fillMaxSize().background(Color(0xFFEEEEEE))
+                        ) {
+                            items(state.products) { item ->
+                                ProductTile(
+                                    product = item,
+                                    onClick = { navigateToProductDetails(item) })
+                            }
                         }
+                        VerticalScrollBarIfSupported(scrollState)
                     }
                 }
             }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListViewModel.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
-import androidx.lifecycle.viewmodel.viewModelFactory
 import co.touchlab.kermit.Logger
 import io.aoriani.ecomm.data.repositories.ProductRepository
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.desktop.kt
+++ b/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.desktop.kt
@@ -2,28 +2,23 @@ package io.aoriani.ecomm.ui.screens.common.components
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.VerticalScrollbar
-import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) {
+actual fun PlatformVerticalScrollbar(scrollState: ScrollState, modifier: Modifier) {
     VerticalScrollbar(
-        modifier = Modifier.align(Alignment.CenterEnd)
-            .fillMaxHeight(),
+        modifier = modifier,
         adapter = rememberScrollbarAdapter(scrollState)
     )
 }
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) {
+actual fun PlatformVerticalScrollbar(scrollState: LazyGridState, modifier: Modifier) {
     VerticalScrollbar(
-        modifier = Modifier.align(Alignment.CenterEnd)
-            .fillMaxHeight(),
+        modifier = modifier,
         adapter = rememberScrollbarAdapter(scrollState)
     )
 }

--- a/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.desktop.kt
+++ b/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.desktop.kt
@@ -1,0 +1,29 @@
+package io.aoriani.ecomm.ui.screens.common.components
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) {
+    VerticalScrollbar(
+        modifier = Modifier.align(Alignment.CenterEnd)
+            .fillMaxHeight(),
+        adapter = rememberScrollbarAdapter(scrollState)
+    )
+}
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) {
+    VerticalScrollbar(
+        modifier = Modifier.align(Alignment.CenterEnd)
+            .fillMaxHeight(),
+        adapter = rememberScrollbarAdapter(scrollState)
+    )
+}

--- a/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.ios.kt
+++ b/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.ios.kt
@@ -1,0 +1,13 @@
+package io.aoriani.ecomm.ui.screens.common.components
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) = Unit
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) = Unit

--- a/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.ios.kt
+++ b/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.ios.kt
@@ -1,13 +1,12 @@
 package io.aoriani.ecomm.ui.screens.common.components
 
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.VerticalScrollbar
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) = Unit
+actual fun PlatformVerticalScrollbar(scrollState: ScrollState, modifier: Modifier) = Unit
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) = Unit
+actual fun PlatformVerticalScrollbar(scrollState: LazyGridState, modifier: Modifier) = Unit

--- a/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.wasmJs.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.wasmJs.kt
@@ -2,28 +2,23 @@ package io.aoriani.ecomm.ui.screens.common.components
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.VerticalScrollbar
-import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) {
+actual fun PlatformVerticalScrollbar(scrollState: ScrollState, modifier: Modifier) {
     VerticalScrollbar(
-        modifier = Modifier.align(Alignment.CenterEnd)
-            .fillMaxHeight(),
+        modifier = modifier,
         adapter = rememberScrollbarAdapter(scrollState)
     )
 }
 
 @Composable
-actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) {
+actual fun PlatformVerticalScrollbar(scrollState: LazyGridState, modifier: Modifier) {
     VerticalScrollbar(
-        modifier = Modifier.align(Alignment.CenterEnd)
-            .fillMaxHeight(),
+        modifier = modifier,
         adapter = rememberScrollbarAdapter(scrollState)
     )
 }

--- a/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.wasmJs.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/ui/screens/common/components/VerticalScrollbarIfSupported.wasmJs.kt
@@ -1,0 +1,29 @@
+package io.aoriani.ecomm.ui.screens.common.components
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.VerticalScrollbar
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.rememberScrollbarAdapter
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: ScrollState) {
+    VerticalScrollbar(
+        modifier = Modifier.align(Alignment.CenterEnd)
+            .fillMaxHeight(),
+        adapter = rememberScrollbarAdapter(scrollState)
+    )
+}
+
+@Composable
+actual fun BoxScope.VerticalScrollBarIfSupported(scrollState: LazyGridState) {
+    VerticalScrollbar(
+        modifier = Modifier.align(Alignment.CenterEnd)
+            .fillMaxHeight(),
+        adapter = rememberScrollbarAdapter(scrollState)
+    )
+}


### PR DESCRIPTION
- Introduced `VerticalScrollbarIfSupported` composable function for displaying a vertical scrollbar when the platform supports it.
- Created platform-specific implementations:
    - `wasmJsMain` and `desktopMain`: Implemented using `VerticalScrollbar`.
    - `androidMain` and `iosMain`: Empty implementations as scrollbars are typically system-provided.
- Integrated `VerticalScrollbarIfSupported` into `ProductDetailsScreen` for its `Column` content.
- Integrated `VerticalScrollbarIfSupported` into `ProductListScreen` for its `LazyVerticalGrid` content.
- Wrapped scrollable content in `ProductDetailsScreen` and `ProductListScreen` with a `Box` to allow `VerticalScrollbarIfSupported` to align to the end.
- Updated `ProductDetailsScreen`'s scrolling `Column` to use `fillMaxSize()`.