### PR TITLE
feat: Configure Ktor tracing with CallId and ClientCallId

### DIFF
--- a/client/TESTING_GUIDELINES.md
+++ b/client/TESTING_GUIDELINES.md
@@ -91,10 +91,10 @@ ViewModel tests are crucial for verifying the UI logic and state management. The
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{Arrange: Create Fake Repository & Test Dispatcher}
-    B --> C{Act: Initialize ViewModel}
-    C --> D{Act: Advance Coroutines}
-    D --> E{Assert: Check ViewModel State}
+    A[Start] --> B[Arrange: Create Fake Repository & Test Dispatcher]
+    B --> C[Act: Initialize ViewModel]
+    C --> D[Act: Advance Coroutines]
+    D --> E[Assert: Check ViewModel State]
     E --> F[End]
 ```
 

--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -119,6 +119,7 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.logging)
+            implementation(libs.ktor.client.callId)
         }
         commonTest.dependencies {
             @OptIn(ExperimentalComposeLibrary::class)

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/data/network/KtorClient.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/data/network/KtorClient.kt
@@ -1,6 +1,7 @@
 package io.aoriani.ecomm.data.network
 
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.callid.CallId
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -16,4 +17,5 @@ fun KtorClient() = HttpClient {
             }
         }
     }
+    install(CallId)
 }

--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-callId = { module = "io.ktor:ktor-client-call-id", version.ref = "ktor" }
 
 # Other
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     implementation(ktorLibs.server.cors)
     implementation(ktorLibs.server.compression)
     implementation(ktorLibs.server.config.yaml)
+    implementation(ktorLibs.server.callId)
+    implementation(ktorLibs.server.callId)
     implementation(libs.logback.classic)
     implementation(libs.expedia.ktor.server.graphql)
     implementation(libs.expedia.hooks.provider)

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -4,11 +4,24 @@ exposed                = "1.0.0-beta-4"
 kotlin-version         = "2.2.20-Beta1"
 kotlinx-serialization  = "1.9.0"
 kotlinx-coroutines-test = "1.10.2"
+ktor = "3.2.2"
 logback-version        = "1.5.18"
 mockk                  = "1.14.5"
 sqlite                 = "3.50.2.0"
 
 [libraries]
+# Ktor
+ktor-server-core              = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-netty             = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-call-logging      = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
+ktor-server-conditional-headers = { module = "io.ktor:ktor-server-conditional-headers", version.ref = "ktor" }
+ktor-server-di                = { module = "io.ktor:ktor-server-di", version.ref = "ktor" }
+ktor-server-cors              = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
+ktor-server-compression       = { module = "io.ktor:ktor-server-compression", version.ref = "ktor" }
+ktor-server-config-yaml       = { module = "io.ktor:ktor-server-config-yaml", version.ref = "ktor" }
+ktor-server-test-host         = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-server-call-id           = { module = "io.ktor:ktor-server-call-id", version.ref = "ktor" }
+
 # GraphQL (Expedia Group)
 expedia-ktor-server-graphql   = { group = "com.expediagroup", name = "graphql-kotlin-ktor-server", version.ref = "expediagroup-graphql" }
 expedia-hooks-provider        = { group = "com.expediagroup", name = "graphql-kotlin-hooks-provider", version.ref = "expediagroup-graphql" }


### PR DESCRIPTION
This PR configures tracing requests in Ktor by installing the `CallId` plugin on the server and `ClientCallId` on the client. This will help in tracking requests across the application.