### PR TITLE
Follow-up: Polish PWA, icons, Gradle DSL, and server tests

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -208,19 +208,17 @@ compose.desktop {
             packageName = "io.aoriani.ecomm"
             packageVersion = "1.0.0"
 
-            nativeDistributions {
-                macOS {
-                    dockName = "eCommerceApp"
-                    iconFile.set(File("src/desktopMain/icons/AppIcon_mac.icns"))
-                }
+            macOS {
+                dockName = "eCommerceApp"
+                iconFile.set(project.file("src/desktopMain/icons/AppIcon_mac.icns"))
+            }
 
-                windows {
-                    iconFile.set(File("src/desktopMain/icons/AppIcon_windows.ico"))
-                }
+            windows {
+                iconFile.set(project.file("src/desktopMain/icons/AppIcon_windows.ico"))
+            }
 
-                linux {
-                    iconFile.set(File("src/desktopMain/icons/AppIcon_linux.png"))
-                }
+            linux {
+                iconFile.set(project.file("src/desktopMain/icons/AppIcon_linux.png"))
             }
         }
     }

--- a/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/main.kt
+++ b/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/main.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import ecommerceapp.composeapp.generated.resources.appIcon
 import ecommerceapp.composeapp.generated.resources.Res
 import io.aoriani.ecomm.ui.window.AboutAppDialog
 import io.aoriani.ecomm.ui.window.DesktopMenuBar

--- a/client/composeApp/src/wasmJsMain/resources/cache_service_worker.js
+++ b/client/composeApp/src/wasmJsMain/resources/cache_service_worker.js
@@ -1,5 +1,5 @@
-const cacheName = 'eCommerceApp-cache-v1';
-const resourcesToCache = [
+const CACHE = 'eCommerceApp-cache-v1';
+const PRECACHE = [
   '.',
   'index.html',
   'styles.css',
@@ -9,23 +9,41 @@ const resourcesToCache = [
   'icon-512.png',
   'icon-192-maskable.png',
   'icon-512-maskable.png',
-  'apple-touch-icon.png'
+  'apple-touch-icon.png',
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
   event.waitUntil(
-    caches.open(cacheName)
-      .then(cache => {
-        return cache.addAll(resourcesToCache);
-      })
+    caches.open(CACHE).then((cache) => cache.addAll(PRECACHE))
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)));
+    await self.clients.claim();
+  })());
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+
+  // Offline navigation fallback for SPA/Compose apps
+  if (req.mode === 'navigate') {
+    event.respondWith((async () => {
+      try { return await fetch(req); } catch {
+        const cache = await caches.open(CACHE);
+        const cached = await cache.match('index.html');
+        return cached || Response.error();
+      }
+    })());
+    return;
+  }
+
+  // Cache-first for static assets
   event.respondWith(
-    caches.match(event.request)
-      .then(response => {
-        return response || fetch(event.request);
-      })
+    caches.match(req).then((cached) => cached || fetch(req))
   );
 });

--- a/client/composeApp/src/wasmJsMain/resources/index.html
+++ b/client/composeApp/src/wasmJsMain/resources/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#000000">
     <title>eCommerceApp</title>
     <link type="text/css" rel="stylesheet" href="styles.css">
     <link rel="icon" href="favicon.ico" sizes="any">
@@ -10,13 +11,17 @@
     <link rel="manifest" href="manifest.webmanifest">
     <script type="application/javascript" src="composeApp.js"></script>
     <script>
-        if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('cache_service_worker.js').then(function(registration) {
-                console.log('Service Worker registered with scope:', registration.scope);
-            }).catch(function(error) {
-                console.log('Service Worker registration failed:', error);
-            });
-        }
+        window.addEventListener('load', function () {
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.register('cache_service_worker.js')
+                    .then(function (registration) {
+                        console.log('Service Worker registered with scope:', registration.scope);
+                    })
+                    .catch(function (error) {
+                        console.log('Service Worker registration failed:', error);
+                    });
+            }
+        });
     </script>
 </head>
 <body>

--- a/client/composeApp/src/wasmJsMain/resources/manifest.webmanifest
+++ b/client/composeApp/src/wasmJsMain/resources/manifest.webmanifest
@@ -1,10 +1,22 @@
 {
+  "id": "/",
   "name": "eCommerceApp",
   "short_name": "eCommerce",
-  "start_url": ".",
+  "start_url": "/",
+  "scope": "/",
   "display": "standalone",
+  "display_override": ["standalone", "fullscreen"],
+  "lang": "en-US",
   "background_color": "#ffffff",
   "theme_color": "#000000",
+  "categories": ["shopping", "productivity"],
+  "shortcuts": [
+    {
+      "name": "Shop",
+      "url": "/",
+      "icons": [{ "src": "icon-192.png", "type": "image/png", "sizes": "192x192" }]
+    }
+  ],
   "icons": [
     { "src": "favicon.ico", "type": "image/x-icon", "sizes": "16x16 32x32" },
     { "src": "icon-192.png", "type": "image/png", "sizes": "192x192" },

--- a/server/src/test/kotlin/dev/aoriani/ecomm/config/CallLoggingConfigTest.kt
+++ b/server/src/test/kotlin/dev/aoriani/ecomm/config/CallLoggingConfigTest.kt
@@ -6,6 +6,7 @@ import ch.qos.logback.core.read.ListAppender
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.config.MapApplicationConfig
@@ -15,6 +16,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import org.slf4j.LoggerFactory
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class CallLoggingConfigTest {
@@ -44,10 +46,10 @@ class CallLoggingConfigTest {
         }
 
         val response = client.get("/log-test")
+        assertEquals(HttpStatusCode.OK, response.status)
         response.bodyAsText() // ensure body consumed
 
         val messages = appender.list.map { it.formattedMessage }
         assertTrue(messages.any { it.startsWith("Request: GET /log-test") && it.contains("Status: 200") })
     }
 }
-

--- a/server/src/test/kotlin/dev/aoriani/ecomm/config/CorsConfigTest.kt
+++ b/server/src/test/kotlin/dev/aoriani/ecomm/config/CorsConfigTest.kt
@@ -30,6 +30,7 @@ class CorsConfigTest {
             headers {
                 append(HttpHeaders.Origin, "http://localhost:8080")
                 append(HttpHeaders.AccessControlRequestMethod, HttpMethod.Get.value)
+                append(HttpHeaders.AccessControlRequestHeaders, HttpHeaders.ContentType)
             }
         }
 


### PR DESCRIPTION
This PR builds on top of PR #35 (base: feature/icons) and applies the review suggestions:

- Gradle DSL: Flatten nested `nativeDistributions` and use `project.file(...)` for icon paths.
- Desktop: Remove unused import; keep window icon setup.
- PWA:
  - Service Worker: add `skipWaiting`, `activate` cleanup, `clients.claim`, and SPA navigation fallback.
  - Index: add `<meta name="theme-color">` and defer SW registration to `window.load`.
  - Manifest: add `id`, `scope`, `lang`, `categories`, `display_override`, and a sample `shortcuts` entry.
- Server tests: Add response status assertion in `CallLoggingConfigTest`; add requested-headers in `CorsConfigTest` preflight.

These changes are non-breaking and aim to strengthen offline behavior, metadata, and build configuration consistency.