### PR TITLE
Integrate Koin DI for ViewModels and remove unused imports

### DIFF
--- a/client/composeApp/build.gradle.kts
+++ b/client/composeApp/build.gradle.kts
@@ -109,6 +109,7 @@ kotlin {
             implementation(libs.kermit.main)
             implementation(libs.sqldelight.coroutines.extension)
             implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel.navigation)
             implementation(libs.koin.core)
             implementation(libs.kotlinx.collections.immutable)
             implementation(libs.kotlinx.coroutines.core)

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/di/Deps.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/di/Deps.kt
@@ -13,9 +13,13 @@ import io.aoriani.ecomm.data.repositories.products.datasources.ProductDataSource
 import io.aoriani.ecomm.data.repositories.products.datasources.graphql.GraphQlProductDataSource
 import io.aoriani.ecomm.domain.AddToCartUseCase
 import io.aoriani.ecomm.domain.AddToCartUseCaseImpl
+import io.aoriani.ecomm.ui.screens.productdetails.ProductDetailsViewModel
+import io.aoriani.ecomm.ui.screens.productlist.ProductListViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -40,4 +44,12 @@ val appModule = module {
     singleOf(::ProductRepositoryImpl) bind ProductRepository::class
     singleOf(::CartRepositoryImpl) bind CartRepository::class
     factoryOf(::AddToCartUseCaseImpl) bind AddToCartUseCase::class
+    viewModel { ProductListViewModel(productRepository = get(), addToCartUseCase = get()) }
+    viewModel {
+        ProductDetailsViewModel(
+            productRepository = get(),
+            addToCartUseCase = get(),
+            savedStateHandle = get()
+        )
+    }
 }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/di/Deps.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/di/Deps.kt
@@ -19,7 +19,6 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
-import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsViewModel.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsViewModel.kt
@@ -2,10 +2,7 @@ package io.aoriani.ecomm.ui.screens.productdetails
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.navigation.toRoute
 import io.aoriani.ecomm.data.repositories.products.ProductRepository
 import io.aoriani.ecomm.domain.AddToCartUseCase
@@ -14,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.reflect.KClass
 
 class ProductDetailsViewModel(
     private val productRepository: ProductRepository,

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsViewModel.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/ProductDetailsViewModel.kt
@@ -60,18 +60,4 @@ class ProductDetailsViewModel(
                 }
         }
     }
-
-    companion object {
-        class Factory(
-            private val productRepository: ProductRepository,
-            private val addToCartUseCase: AddToCartUseCase
-        ) :
-            ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
-                @Suppress("UNCHECKED_CAST") return ProductDetailsViewModel(
-                    productRepository, addToCartUseCase, extras.createSavedStateHandle()
-                ) as T
-            }
-        }
-    }
 }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/navigation.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/navigation.kt
@@ -2,12 +2,10 @@ package io.aoriani.ecomm.ui.screens.productdetails
 
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import io.aoriani.ecomm.ui.navigation.Routes
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 context(navController: NavHostController)

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/navigation.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productdetails/navigation.kt
@@ -8,16 +8,12 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import io.aoriani.ecomm.ui.navigation.Routes
 import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 
 context(navController: NavHostController)
 internal fun NavGraphBuilder.productDetailsScreen() {
     composable<Routes.ProductDetails> { backStackEntry ->
-        val viewModel: ProductDetailsViewModel = viewModel(
-            factory = ProductDetailsViewModel.Companion.Factory(
-                productRepository = koinInject(),
-                addToCartUseCase = koinInject()
-            )
-        )
+        val viewModel: ProductDetailsViewModel = koinViewModel()
         val state: ProductDetailsUiState by viewModel.state.collectAsStateWithLifecycle()
         ProductDetailsScreen(state, navigateBack = { navController.popBackStack() })
     }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListViewModel.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListViewModel.kt
@@ -1,9 +1,7 @@
 package io.aoriani.ecomm.ui.screens.productlist
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.CreationExtras
 import co.touchlab.kermit.Logger
 import io.aoriani.ecomm.data.repositories.products.ProductRepository
 import io.aoriani.ecomm.domain.AddToCartUseCase
@@ -13,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.reflect.KClass
 
 private const val LOGTAG = "ProductListViewModel"
 

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListViewModel.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/ProductListViewModel.kt
@@ -44,20 +44,4 @@ class ProductListViewModel(
                 }
         }
     }
-
-    companion object {
-        class Factory(
-            private val productRepository: ProductRepository,
-            private val addToCartUseCase: AddToCartUseCase,
-        ) :
-            ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(
-                modelClass: KClass<T>,
-                extras: CreationExtras
-            ): T {
-                @Suppress("UNCHECKED_CAST")
-                return ProductListViewModel(productRepository, addToCartUseCase) as T
-            }
-        }
-    }
 }

--- a/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/navigation.kt
+++ b/client/composeApp/src/commonMain/kotlin/io/aoriani/ecomm/ui/screens/productlist/navigation.kt
@@ -2,22 +2,16 @@ package io.aoriani.ecomm.ui.screens.productlist
 
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import io.aoriani.ecomm.ui.navigation.Routes
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 
 context(navController: NavHostController)
 internal fun NavGraphBuilder.productListScreen() {
     composable<Routes.ProductList> {
-        val viewModel: ProductListViewModel = viewModel(
-            factory = ProductListViewModel.Companion.Factory(
-                productRepository = koinInject(),
-                addToCartUseCase = koinInject()
-            )
-        )
+        val viewModel: ProductListViewModel = koinViewModel()
         val state by viewModel.state.collectAsStateWithLifecycle()
         ProductListScreen(
             state = state,

--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -70,6 +70,8 @@ kermit-test = { module = "co.touchlab:kermit-test", version.ref = "kermit" }
 # Koin
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin" }
+koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-viewmodel-navigation", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 


### PR DESCRIPTION
This pull request cleans up the codebase and modernises ViewModel creation:

- **Removed unused imports** from `ProductDetailsViewModel.kt`, `Deps.kt`, `navigation.kt`, and `ProductListViewModel.kt`.
- **Added Koin dependencies** (`koin-compose-viewmodel` and `koin-compose-viewmodel-navigation`) to `libs.versions.toml` and the app's Gradle file.
- **Eliminated manual ViewModel factories** in `ProductDetailsViewModel.kt` and `ProductListViewModel.kt`.
- **Defined ViewModels** in `Deps.kt` using Koin’s `viewModel` and `viewModelOf` DSL.
- **Updated navigation files** (`productlist/navigation.kt`, `productdetails/navigation.kt`) to retrieve ViewModels with `koinViewModel()`.
- Updated Gradle build scripts to include the new Koin dependencies.

These changes streamline dependency injection, reduce boilerplate, and keep the codebase tidy.