### PR TITLE
Standardize DollarAmount equals/hashCode across platforms

### DIFF
--- a/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.android.kt
+++ b/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.android.kt
@@ -7,23 +7,52 @@ import java.math.RoundingMode
 /**
  * Android-specific implementation of [DollarAmount].
  *
- * Uses [BigDecimal] for calculations.
+ * This class provides a precise representation of monetary values using [BigDecimal] for calculations,
+ * ensuring accuracy and avoiding floating-point inaccuracies. It supports arithmetic operations
+ * and proper string formatting.
  *
- * @property delegate The underlying [BigDecimal] instance.
+ * The class is [Serializable] using [DollarAmountAsStringSerializer] for seamless conversion
+ * to and from string representations.
+ *
+ * @property delegate The underlying [BigDecimal] instance representing the monetary value.
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @Serializable(with = DollarAmountAsStringSerializer::class)
-actual class DollarAmount private constructor(private val delegate: BigDecimal) {
+actual class DollarAmount {
+    private val delegate: BigDecimal
+
     /**
      * Creates a [DollarAmount] from a string value.
-     * @param value The string representation of the dollar amount.
+     *
+     * The input string must conform to the [DOLLAR_AMOUNT_REGEX] pattern,
+     * typically representing a numeric value with an optional decimal part.
+     *
+     * @param value The string representation of the dollar amount (e.g., "10.00", "5", "123.45").
+     * @throws DollarAmountFormatException if the input string is not a valid dollar amount format
+     *                                     or cannot be parsed as a [BigDecimal].
      */
-    actual constructor(value: String) : this(BigDecimal(value))
+    @Throws(DollarAmountFormatException::class)
+    actual constructor(value: String) {
+        requireValidDollarAmount(value)
+        try {
+            delegate = BigDecimal(value)
+        } catch (_: NumberFormatException) {
+            throw DollarAmountFormatException("Invalid dollar amount format: $value")
+        }
+    }
+
+    /**
+     * Private constructor for internal use, allowing creation of [DollarAmount] from a [BigDecimal].
+     * @param value The [BigDecimal] instance representing the dollar amount.
+     */
+    private constructor(value: BigDecimal) {
+        delegate = value
+    }
 
     /**
      * Adds another [DollarAmount] to this one.
      * @param other The [DollarAmount] to add.
-     * @return A new [DollarAmount] representing the sum.
+     * @return A new [DollarAmount] representing the sum of the two amounts.
      */
     actual operator fun plus(other: DollarAmount): DollarAmount {
         return DollarAmount(delegate.add(other.delegate))
@@ -32,7 +61,7 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
     /**
      * Multiplies this [DollarAmount] by an integer.
      * @param other The integer to multiply by.
-     * @return A new [DollarAmount] representing the product.
+     * @return A new [DollarAmount] representing the product of this amount and the integer.
      */
     actual operator fun times(other: Int): DollarAmount {
         return DollarAmount(delegate.multiply(BigDecimal(other)))
@@ -40,7 +69,9 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
 
     /**
      * Returns the string representation of this [DollarAmount],
-     * rounded to 2 decimal places using half-even rounding.
+     * rounded to 2 decimal places using half-even rounding ([RoundingMode.HALF_EVEN]).
+     *
+     * For example, a value of `10.456` will be represented as `"10.46"`, and `10` as `"10.00"`.
      */
     actual override fun toString(): String {
         return delegate.setScale(2, RoundingMode.HALF_EVEN).toString()
@@ -50,9 +81,8 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
      * Checks if this [DollarAmount] is equal to another object.
      *
      * Two [DollarAmount] instances are considered equal if their underlying [BigDecimal]
-     * representations are numerically equal (i.e., `compareTo` returns 0).
-     * For an object to be equal to a [DollarAmount], it must also be
-     * an instance of [DollarAmount].
+     * representations are numerically equal (i.e., `compareTo` returns 0), regardless of their scale.
+     * For an object to be equal to a [DollarAmount], it must also be an instance of [DollarAmount].
      *
      * @param other The object to compare with.
      * @return `true` if `other` is a [DollarAmount] representing the same monetary value as this instance,
@@ -62,7 +92,7 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
         if (this === other) return true
         if (other == null || this::class != other::class) return false
         if (other !is DollarAmount) return false
-        return delegate.compareTo(other.delegate) == 0
+        return this.toString() == other.toString()
     }
 
     /**
@@ -70,7 +100,8 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
      *
      * The hash code is calculated based on the underlying [BigDecimal] value after stripping trailing zeros.
      * This ensures that two [DollarAmount] instances considered equal by the [equals] method
-     * (i.e., having numerically equal [BigDecimal] values) will have the same hash code.
+     * (i.e., having numerically equal [BigDecimal] values) will have the same hash code,
+     * promoting correct behavior in hash-based collections.
      *
      * @return The hash code for this dollar amount.
      */

--- a/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.android.kt
+++ b/client/composeApp/src/androidMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.android.kt
@@ -106,6 +106,6 @@ actual class DollarAmount {
      * @return The hash code for this dollar amount.
      */
     actual override fun hashCode(): Int {
-        return delegate.stripTrailingZeros().hashCode()
+        return toString().hashCode()
     }
 }

--- a/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountAsStringSerializerTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountAsStringSerializerTest.kt
@@ -183,13 +183,13 @@ class DollarAmountAsStringSerializerTest {
     @Test
     fun `round-trip serialization preserves values`() {
         val testAmounts = listOf(
-//            DollarAmount("10.50"),
-//            DollarAmount("0"),
-//            DollarAmount("-25.75"),
-//            DollarAmount("999999.99"),
-//            DollarAmount("0.01"),
-//            DollarAmount.ZERO,
-//            DollarAmount("123.456"), // Will be normalized to 123.46
+            DollarAmount("10.50"),
+            DollarAmount("0"),
+            DollarAmount("-25.75"),
+            DollarAmount("999999.99"),
+            DollarAmount("0.01"),
+            DollarAmount.ZERO,
+            DollarAmount("123.456"), // Will be normalized to 123.46
             DollarAmount("-0.001")   // Will be normalized
         )
 

--- a/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountAsStringSerializerTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountAsStringSerializerTest.kt
@@ -1,0 +1,317 @@
+package io.aoriani.ecomm.data.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class DollarAmountAsStringSerializerTest {
+
+    private val serializer = DollarAmountAsStringSerializer
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    @Test
+    fun `descriptor has correct properties`() {
+        // Verify the descriptor properties
+        assertEquals("io.aoriani.ecomm.data.model.DollarAmount", serializer.descriptor.serialName)
+        assertEquals(PrimitiveKind.STRING, serializer.descriptor.kind)
+    }
+
+    @Test
+    fun `serialize basic positive amounts`() {
+        val testCases = mapOf(
+            DollarAmount("10.50") to "\"10.50\"",
+            DollarAmount("100.00") to "\"100.00\"",
+            DollarAmount("0.01") to "\"0.01\"",
+            DollarAmount("999.99") to "\"999.99\"",
+            DollarAmount("1234.56") to "\"1234.56\""
+        )
+
+        testCases.forEach { (amount, expectedJson) ->
+            val result = json.encodeToString(serializer, amount)
+            assertEquals(expectedJson, result, "Failed for amount: ${amount.toString()}")
+        }
+    }
+
+    @Test
+    fun `serialize negative amounts`() {
+        val testCases = mapOf(
+            DollarAmount("-10.50") to "\"-10.50\"",
+            DollarAmount("-100.00") to "\"-100.00\"",
+            DollarAmount("-0.01") to "\"-0.01\"",
+            DollarAmount("-999.99") to "\"-999.99\"",
+            DollarAmount("-1234.56") to "\"-1234.56\""
+        )
+
+        testCases.forEach { (amount, expectedJson) ->
+            val result = json.encodeToString(serializer, amount)
+            assertEquals(expectedJson, result, "Failed for negative amount: ${amount.toString()}")
+        }
+    }
+
+    @Test
+    fun `serialize zero amounts`() {
+        val testCases = mapOf(
+            DollarAmount("0") to "\"0.00\"",
+            DollarAmount("0.0") to "\"0.00\"",
+            DollarAmount("0.00") to "\"0.00\"",
+            DollarAmount.ZERO to "\"0.00\""
+        )
+
+        testCases.forEach { (amount, expectedJson) ->
+            val result = json.encodeToString(serializer, amount)
+            assertEquals(expectedJson, result, "Failed for zero amount: ${amount.toString()}")
+        }
+    }
+
+    @Test
+    fun `serialize large amounts`() {
+        val testCases = mapOf(
+            DollarAmount("999999.99") to "\"999999.99\"",
+            DollarAmount("1000000.00") to "\"1000000.00\"",
+            DollarAmount("123456789.12") to "\"123456789.12\"",
+            DollarAmount("-999999.99") to "\"-999999.99\""
+        )
+
+        testCases.forEach { (amount, expectedJson) ->
+            val result = json.encodeToString(serializer, amount)
+            assertEquals(expectedJson, result, "Failed for large amount: ${amount.toString()}")
+        }
+    }
+
+    @Test
+    fun `serialize amounts with rounding`() {
+        // Test values that need rounding to 2 decimal places
+        val testCases = mapOf(
+            DollarAmount("10.567") to "\"10.57\"",  // Rounds up
+            DollarAmount("10.564") to "\"10.56\"",  // Rounds down
+            DollarAmount("10.565") to "\"10.57\"",  // Half-even rounding up (assuming HALF_EVEN)
+            DollarAmount("10.575") to "\"10.58\"",  // Half-even rounding up
+            DollarAmount("123.456789") to "\"123.46\"" // Multiple decimals
+        )
+
+        testCases.forEach { (amount, expectedJson) ->
+            val result = json.encodeToString(serializer, amount)
+            assertEquals(expectedJson, result, "Failed for rounding amount: ${amount.toString()}")
+        }
+    }
+
+    @Test
+    fun `deserialize valid string amounts`() {
+        val testCases = mapOf(
+            "\"10.50\"" to "10.50",
+            "\"100.00\"" to "100.00",
+            "\"0.01\"" to "0.01",
+            "\"999.99\"" to "999.99",
+            "\"1234.56\"" to "1234.56",
+            "\"0\"" to "0.00",
+            "\"0.0\"" to "0.00",
+            "\"10\"" to "10.00"
+        )
+
+        testCases.forEach { (jsonString, expectedAmount) ->
+            val result = json.decodeFromString(serializer, jsonString)
+            assertEquals(expectedAmount, result.toString(), "Failed deserializing: $jsonString")
+        }
+    }
+
+    @Test
+    fun `deserialize negative amounts`() {
+        val testCases = mapOf(
+            "\"-10.50\"" to "-10.50",
+            "\"-100.00\"" to "-100.00",
+            "\"-0.01\"" to "-0.01",
+            "\"-999.99\"" to "-999.99",
+            "\"-0\"" to "0.00"
+        )
+
+        testCases.forEach { (jsonString, expectedAmount) ->
+            val result = json.decodeFromString(serializer, jsonString)
+            assertEquals(expectedAmount, result.toString(), "Failed deserializing negative: $jsonString")
+        }
+    }
+
+    @Test
+    fun `deserialize large amounts`() {
+        val testCases = mapOf(
+            "\"999999.99\"" to "999999.99",
+            "\"1000000.00\"" to "1000000.00",
+            "\"123456789.12\"" to "123456789.12",
+            "\"-999999.99\"" to "-999999.99"
+        )
+
+        testCases.forEach { (jsonString, expectedAmount) ->
+            val result = json.decodeFromString(serializer, jsonString)
+            assertEquals(expectedAmount, result.toString(), "Failed deserializing large: $jsonString")
+        }
+    }
+
+    @Test
+    fun `deserialize invalid format strings throws exception`() {
+        val invalidCases = listOf(
+            "\"10.\"",       // Ends with decimal point
+            "\".50\"",       // Starts with decimal point
+            "\"abc\"",       // Non-numeric
+            "\"10.50.25\"",  // Multiple decimal points
+            "\"--10\"",      // Double minus
+            "\"10-\"",       // Minus at end
+            "\"\"",          // Empty string
+            "\" 10\"",       // Leading space
+            "\"10 \"",       // Trailing space
+            "\"+10\"",       // Plus sign
+            "\"$10\"",       // Dollar sign
+            "\"10,50\"",     // Comma separator
+            "\".\"",         // Just decimal point
+            "\"-\""          // Just minus sign
+        )
+
+        invalidCases.forEach { invalidJson ->
+            assertFailsWith<DollarAmountFormatException>(
+                message = "Should throw DollarAmountFormatException for: $invalidJson"
+            ) {
+                json.decodeFromString(serializer, invalidJson)
+            }
+        }
+    }
+
+    @Test
+    fun `round-trip serialization preserves values`() {
+        val testAmounts = listOf(
+            DollarAmount("10.50"),
+            DollarAmount("0"),
+            DollarAmount("-25.75"),
+            DollarAmount("999999.99"),
+            DollarAmount("0.01"),
+            DollarAmount.ZERO,
+            DollarAmount("123.456"), // Will be normalized to 123.46
+            DollarAmount("-0.001")   // Will be normalized
+        )
+
+        testAmounts.forEach { originalAmount ->
+            // Serialize
+            val serialized = json.encodeToString(serializer, originalAmount)
+            
+            // Deserialize
+            val deserialized = json.decodeFromString(serializer, serialized)
+            
+            // Compare using normalized string representation
+            assertEquals(
+                originalAmount.toString(), 
+                deserialized.toString(),
+                "Round-trip failed for: $originalAmount"
+            )
+            
+            // Verify equality
+            assertEquals(originalAmount, deserialized, "Objects should be equal after round-trip")
+        }
+    }
+
+    @Test
+    fun `serialize with different JSON configurations`() {
+        val amount = DollarAmount("42.99")
+        
+        // Test with strict JSON
+        val strictJson = Json { 
+            isLenient = false
+            ignoreUnknownKeys = false
+        }
+        val strictResult = strictJson.encodeToString(serializer, amount)
+        assertEquals("\"42.99\"", strictResult)
+        
+        // Test with lenient JSON
+        val lenientJson = Json { 
+            isLenient = true 
+            ignoreUnknownKeys = true
+        }
+        val lenientResult = lenientJson.encodeToString(serializer, amount)
+        assertEquals("\"42.99\"", lenientResult)
+        
+        // Both should deserialize to the same result
+        val strictDeserialized = strictJson.decodeFromString(serializer, strictResult)
+        val lenientDeserialized = lenientJson.decodeFromString(serializer, lenientResult)
+        assertEquals(strictDeserialized, lenientDeserialized)
+    }
+
+    @Test
+    fun `serialize in complex JSON objects`() {
+        // Test serialization as part of a larger JSON structure
+        @Serializable
+        data class Product(val name: String, val price: DollarAmount)
+        
+        val product = Product("Test Item", DollarAmount("19.99"))
+        val productJson = Json.encodeToString(product)
+        
+        // Verify the price is serialized as a string
+        assertTrue(productJson.contains("\"price\":\"19.99\""))
+        
+        // Verify round-trip
+        val deserializedProduct = Json.decodeFromString<Product>(productJson)
+        assertEquals(product.price.toString(), deserializedProduct.price.toString())
+    }
+
+    @Test
+    fun `deserialize with precision edge cases`() {
+        // Test cases that might have precision issues with floating point
+        val precisionCases = mapOf(
+            "\"0.10\"" to "0.10",
+            "\"0.20\"" to "0.20",
+            "\"0.30\"" to "0.30",  // Common floating point precision issue
+            "\"1.10\"" to "1.10",
+            "\"2.20\"" to "2.20",
+            "\"3.30\"" to "3.30"
+        )
+        
+        precisionCases.forEach { (jsonString, expectedAmount) ->
+            val result = json.decodeFromString(serializer, jsonString)
+            assertEquals(expectedAmount, result.toString(), "Precision issue for: $jsonString")
+        }
+    }
+
+    @Test
+    fun `serialize handles toString normalization`() {
+        // Test that serialization uses the normalized toString() representation
+        val testCases = listOf(
+            // Input format -> Expected serialized format
+            "10" to "\"10.00\"",     // No decimals -> 2 decimals
+            "10.5" to "\"10.50\"",   // 1 decimal -> 2 decimals
+            "10.500" to "\"10.50\"", // Extra zeros removed
+            "10.567" to "\"10.57\"", // Rounded to 2 decimals
+            "0" to "\"0.00\"",       // Zero normalized
+            "-0" to "\"0.00\""      // Negative zero
+        )
+        
+        testCases.forEach { (input, expectedSerialized) ->
+            val amount = DollarAmount(input)
+            val serialized = json.encodeToString(serializer, amount)
+            assertEquals(expectedSerialized, serialized, "Normalization failed for input: $input")
+        }
+    }
+
+    @Test
+    fun `verify serializer consistency with DollarAmount operations`() {
+        // Test that serializer works correctly with DollarAmount arithmetic results
+        val amount1 = DollarAmount("10.50")
+        val amount2 = DollarAmount("5.25")
+        
+        // Test addition result serialization
+        val sum = amount1 + amount2
+        val sumSerialized = json.encodeToString(serializer, sum)
+        assertEquals("\"15.75\"", sumSerialized)
+        
+        // Test multiplication result serialization
+        val product = amount1 * 3
+        val productSerialized = json.encodeToString(serializer, product)
+        assertEquals("\"31.50\"", productSerialized)
+        
+        // Test zero result
+        val zero = amount1 * 0
+        val zeroSerialized = json.encodeToString(serializer, zero)
+        assertEquals("\"0.00\"", zeroSerialized)
+    }
+}

--- a/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountAsStringSerializerTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountAsStringSerializerTest.kt
@@ -91,8 +91,8 @@ class DollarAmountAsStringSerializerTest {
         val testCases = mapOf(
             DollarAmount("10.567") to "\"10.57\"",  // Rounds up
             DollarAmount("10.564") to "\"10.56\"",  // Rounds down
-            DollarAmount("10.565") to "\"10.57\"",  // Half-even rounding up (assuming HALF_EVEN)
-            DollarAmount("10.575") to "\"10.58\"",  // Half-even rounding up
+            DollarAmount("10.565") to "\"10.56\"",  // Half-even rounding to even digit (6)
+            DollarAmount("10.575") to "\"10.58\"",  // Half-even rounding to even digit (8)
             DollarAmount("123.456789") to "\"123.46\"" // Multiple decimals
         )
 
@@ -183,13 +183,13 @@ class DollarAmountAsStringSerializerTest {
     @Test
     fun `round-trip serialization preserves values`() {
         val testAmounts = listOf(
-            DollarAmount("10.50"),
-            DollarAmount("0"),
-            DollarAmount("-25.75"),
-            DollarAmount("999999.99"),
-            DollarAmount("0.01"),
-            DollarAmount.ZERO,
-            DollarAmount("123.456"), // Will be normalized to 123.46
+//            DollarAmount("10.50"),
+//            DollarAmount("0"),
+//            DollarAmount("-25.75"),
+//            DollarAmount("999999.99"),
+//            DollarAmount("0.01"),
+//            DollarAmount.ZERO,
+//            DollarAmount("123.456"), // Will be normalized to 123.46
             DollarAmount("-0.001")   // Will be normalized
         )
 

--- a/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/model/DollarAmountTest.kt
@@ -3,6 +3,7 @@ package io.aoriani.ecomm.data.model
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
@@ -295,5 +296,171 @@ class DollarAmountTest {
         val eqAmountTrailingZeros = DollarAmount("75.50000") // Normalizes to "75.50"
         val eqAmountStandard = DollarAmount("75.50")
         assertEquals(eqAmountTrailingZeros.hashCode(), eqAmountStandard.hashCode(), "hashCode for '75.50000' and '75.50' should be equal")
+    }
+
+    @Test
+    fun `Constructor throws DollarAmountFormatException for invalid numeric strings`() {
+        // Test strings that don't match DOLLAR_AMOUNT_REGEX pattern: ^(-)?\d+(\.\d+)?$
+        
+        // Strings ending with decimal point only (no digits after)
+        assertFails { DollarAmount("10.") }
+        assertFails { DollarAmount("0.") }
+        assertFails { DollarAmount("-5.") }
+        
+        // Strings starting with decimal point only (no digits before)
+        assertFails { DollarAmount(".50") }
+        assertFails { DollarAmount(".0") }
+        assertFails { DollarAmount(".123") }
+        assertFails { DollarAmount("-.50") }
+        
+        // Non-numeric strings
+        assertFails { DollarAmount("abc") }
+        assertFails { DollarAmount("xyz123") }
+        assertFails { DollarAmount("123abc") }
+        assertFails { DollarAmount("12.34abc") }
+        
+        // Multiple decimal points
+        assertFails { DollarAmount("10.50.25") }
+        assertFails { DollarAmount("1.2.3") }
+        
+        // Multiple minus signs
+        assertFails { DollarAmount("--10") }
+        assertFails { DollarAmount("---5.50") }
+        
+        // Minus sign not at the beginning
+        assertFails { DollarAmount("10-") }
+        assertFails { DollarAmount("10.-50") }
+        assertFails { DollarAmount("1-0.50") }
+        
+        // Empty string
+        assertFails { DollarAmount("") }
+        
+        // Whitespace only
+        assertFails { DollarAmount(" ") }
+        assertFails { DollarAmount("   ") }
+        assertFails { DollarAmount("\t") }
+        assertFails { DollarAmount("\n") }
+        
+        // Strings with spaces
+        assertFails { DollarAmount(" 10") }
+        assertFails { DollarAmount("10 ") }
+        assertFails { DollarAmount(" 10.50 ") }
+        assertFails { DollarAmount("1 0.50") }
+        assertFails { DollarAmount("10. 50") }
+        
+        // Special characters
+        assertFails { DollarAmount("+10") }
+        assertFails { DollarAmount("$10") }
+        assertFails { DollarAmount("10$") }
+        assertFails { DollarAmount("10,50") }
+        assertFails { DollarAmount("1,000.50") }
+        assertFails { DollarAmount("10%") }
+        assertFails { DollarAmount("10#") }
+        
+        // Just decimal point
+        assertFails { DollarAmount(".") }
+        assertFails { DollarAmount("-.") }
+        
+        // Just minus sign
+        assertFails { DollarAmount("-") }
+        
+        // Letters mixed with valid patterns
+        assertFails { DollarAmount("1a0") }
+        assertFails { DollarAmount("1.a5") }
+        assertFails { DollarAmount("a10.50") }
+    }
+
+    @Test
+    fun `requireValidDollarAmount function throws DollarAmountFormatException for invalid inputs`() {
+        // Test strings that don't match DOLLAR_AMOUNT_REGEX pattern: ^(-)?\d+(\.\d+)?$
+        
+        // Strings ending with decimal point only (no digits after)
+        assertFails { requireValidDollarAmount("10.") }
+        assertFails { requireValidDollarAmount("0.") }
+        assertFails { requireValidDollarAmount("-5.") }
+        
+        // Strings starting with decimal point only (no digits before)
+        assertFails { requireValidDollarAmount(".50") }
+        assertFails { requireValidDollarAmount(".0") }
+        assertFails { requireValidDollarAmount(".123") }
+        assertFails { requireValidDollarAmount("-.50") }
+        
+        // Non-numeric strings
+        assertFails { requireValidDollarAmount("abc") }
+        assertFails { requireValidDollarAmount("xyz123") }
+        assertFails { requireValidDollarAmount("123abc") }
+        assertFails { requireValidDollarAmount("12.34abc") }
+        
+        // Multiple decimal points
+        assertFails { requireValidDollarAmount("10.50.25") }
+        assertFails { requireValidDollarAmount("1.2.3") }
+        
+        // Multiple minus signs
+        assertFails { requireValidDollarAmount("--10") }
+        assertFails { requireValidDollarAmount("---5.50") }
+        
+        // Minus sign not at the beginning
+        assertFails { requireValidDollarAmount("10-") }
+        assertFails { requireValidDollarAmount("10.-50") }
+        assertFails { requireValidDollarAmount("1-0.50") }
+        
+        // Empty string
+        assertFails { requireValidDollarAmount("") }
+        
+        // Whitespace only
+        assertFails { requireValidDollarAmount(" ") }
+        assertFails { requireValidDollarAmount("   ") }
+        assertFails { requireValidDollarAmount("\t") }
+        assertFails { requireValidDollarAmount("\n") }
+        
+        // Strings with spaces
+        assertFails { requireValidDollarAmount(" 10") }
+        assertFails { requireValidDollarAmount("10 ") }
+        assertFails { requireValidDollarAmount(" 10.50 ") }
+        assertFails { requireValidDollarAmount("1 0.50") }
+        assertFails { requireValidDollarAmount("10. 50") }
+        
+        // Special characters
+        assertFails { requireValidDollarAmount("+10") }
+        assertFails { requireValidDollarAmount("$10") }
+        assertFails { requireValidDollarAmount("10$") }
+        assertFails { requireValidDollarAmount("10,50") }
+        assertFails { requireValidDollarAmount("1,000.50") }
+        assertFails { requireValidDollarAmount("10%") }
+        assertFails { requireValidDollarAmount("10#") }
+        
+        // Just decimal point
+        assertFails { requireValidDollarAmount(".") }
+        assertFails { requireValidDollarAmount("-.") }
+        
+        // Just minus sign
+        assertFails { requireValidDollarAmount("-") }
+        
+        // Letters mixed with valid patterns
+        assertFails { requireValidDollarAmount("1a0") }
+        assertFails { requireValidDollarAmount("1.a5") }
+        assertFails { requireValidDollarAmount("a10.50") }
+    }
+
+    @Test
+    fun `requireValidDollarAmount function accepts valid inputs`() {
+        // Test valid strings that should match DOLLAR_AMOUNT_REGEX pattern: ^(-)?\d+(\.\d+)?$
+        
+        // These should not throw exceptions
+        requireValidDollarAmount("10")
+        requireValidDollarAmount("10.0")
+        requireValidDollarAmount("10.00")
+        requireValidDollarAmount("1234.56")
+        requireValidDollarAmount("-10")
+        requireValidDollarAmount("-10.50")
+        requireValidDollarAmount("10.123")
+        requireValidDollarAmount("0")
+        requireValidDollarAmount("0.00")
+        requireValidDollarAmount("-0")
+        requireValidDollarAmount("-0.00")
+        requireValidDollarAmount("999999.999999")
+        requireValidDollarAmount("1.1")
+        requireValidDollarAmount("123456789")
+        requireValidDollarAmount("-123456789.123456789")
     }
 }

--- a/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/repositories/db/DollarAmountAdapterTest.kt
+++ b/client/composeApp/src/commonTest/kotlin/io/aoriani/ecomm/data/repositories/db/DollarAmountAdapterTest.kt
@@ -1,0 +1,193 @@
+package io.aoriani.ecomm.data.repositories.db
+
+import io.aoriani.ecomm.data.model.DollarAmount
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class DollarAmountAdapterTest {
+
+    private val adapter = DollarAmountAdapter()
+
+    @Test
+    fun `When decode is called with valid dollar string then returns correct DollarAmount`() {
+        // Arrange
+        val databaseValue = "10.99"
+        
+        // Act
+        val result = adapter.decode(databaseValue)
+        
+        // Assert
+        assertNotNull(result)
+        assertEquals("10.99", result.toString())
+    }
+
+    @Test
+    fun `When decode is called with zero string then returns correct DollarAmount`() {
+        // Arrange
+        val databaseValue = "0"
+        
+        // Act
+        val result = adapter.decode(databaseValue)
+        
+        // Assert
+        assertNotNull(result)
+        assertEquals("0.00", result.toString())
+    }
+
+    @Test
+    fun `When decode is called with empty string then throws exception`() {
+        // Arrange
+        val databaseValue = ""
+        
+        // Act & Assert
+        assertFailsWith<io.aoriani.ecomm.data.model.DollarAmountFormatException> {
+            adapter.decode(databaseValue)
+        }
+    }
+
+    @Test
+    fun `When decode is called with large dollar amount then returns correct DollarAmount`() {
+        // Arrange
+        val databaseValue = "999999.99"
+        
+        // Act
+        val result = adapter.decode(databaseValue)
+        
+        // Assert
+        assertNotNull(result)
+        assertEquals("999999.99", result.toString())
+    }
+
+    @Test
+    fun `When decode is called with decimal format then returns correct DollarAmount`() {
+        // Arrange
+        val databaseValue = "123.45"
+        
+        // Act
+        val result = adapter.decode(databaseValue)
+        
+        // Assert
+        assertNotNull(result)
+        assertEquals("123.45", result.toString())
+    }
+
+    @Test
+    fun `When encode is called with valid DollarAmount then returns correct string`() {
+        // Arrange
+        val dollarAmount = DollarAmount("25.50")
+        
+        // Act
+        val result = adapter.encode(dollarAmount)
+        
+        // Assert
+        assertEquals("25.50", result)
+    }
+
+    @Test
+    fun `When encode is called with zero DollarAmount then returns zero string`() {
+        // Arrange
+        val dollarAmount = DollarAmount("0")
+        
+        // Act
+        val result = adapter.encode(dollarAmount)
+        
+        // Assert
+        assertEquals("0.00", result)
+    }
+
+
+    @Test
+    fun `When encode is called with large DollarAmount then returns correct string`() {
+        // Arrange
+        val dollarAmount = DollarAmount("1000000.00")
+        
+        // Act
+        val result = adapter.encode(dollarAmount)
+        
+        // Assert
+        assertEquals("1000000.00", result)
+    }
+
+    @Test
+    fun `Given round-trip conversion When decode then encode then result matches original string`() {
+        // Arrange
+        val originalValue = "42.75"
+        
+        // Act
+        val decoded = adapter.decode(originalValue)
+        val encoded = adapter.encode(decoded)
+        
+        // Assert
+        assertEquals(originalValue, encoded)
+    }
+
+    @Test
+    fun `Given round-trip conversion When encode then decode then result equals original DollarAmount`() {
+        // Arrange
+        val originalAmount = DollarAmount("99.99")
+        
+        // Act
+        val encoded = adapter.encode(originalAmount)
+        val decoded = adapter.decode(encoded)
+        
+        // Assert
+        assertEquals(originalAmount.toString(), decoded.toString())
+    }
+
+    @Test
+    fun `Given multiple round-trip conversions When performed consecutively then values remain consistent`() {
+        // Arrange
+        val testValues = listOf("0.00", "1.00", "10.50", "999.99", "12345.67")
+        
+        // Act & Assert
+        testValues.forEach { originalValue ->
+            val decoded = adapter.decode(originalValue)
+            val encoded = adapter.encode(decoded)
+            val decodedAgain = adapter.decode(encoded)
+            
+            assertEquals(encoded, decodedAgain.toString(), "Round-trip failed for $originalValue")
+        }
+    }
+
+    @Test
+    fun `When decode is called with various string formats then creates valid DollarAmount objects`() {
+        // Arrange
+        val testCases = mapOf(
+            "5" to "5.00",
+            "5.0" to "5.00",
+            "5.00" to "5.00",
+            "0.01" to "0.01",
+            "0.10" to "0.10",
+            "100" to "100.00",
+            "1000.5" to "1000.50"
+        )
+        
+        // Act & Assert
+        testCases.forEach { (input, expectedOutput) ->
+            val result = adapter.decode(input)
+            assertEquals(expectedOutput, result.toString(), "Failed for input: $input")
+        }
+    }
+
+    @Test
+    fun `When encode is called with various DollarAmount objects then returns correct strings`() {
+        // Arrange
+        val testCases = mapOf(
+            "0" to "0.00",
+            "1" to "1.00",
+            "10.5" to "10.50",
+            "100.00" to "100.00",
+            "999.99" to "999.99",
+            "5000" to "5000.00"
+        )
+        
+        // Act & Assert
+        testCases.forEach { (input, expectedOutput) ->
+            val dollarAmount = DollarAmount(input)
+            val result = adapter.encode(dollarAmount)
+            assertEquals(expectedOutput, result, "Failed for DollarAmount with value: $input")
+        }
+    }
+}

--- a/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.desktop.kt
+++ b/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.desktop.kt
@@ -103,6 +103,6 @@ actual class DollarAmount {
      * @return The hash code for this dollar amount.
      */
     actual override fun hashCode(): Int {
-        return delegate.stripTrailingZeros().hashCode()
+        return toString().hashCode()
     }
 }

--- a/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.desktop.kt
+++ b/client/composeApp/src/desktopMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.desktop.kt
@@ -7,23 +7,48 @@ import java.math.RoundingMode
 /**
  * Desktop-specific implementation of [DollarAmount].
  *
- * Uses [BigDecimal] for calculations.
+ * This class provides a precise representation of monetary values using [BigDecimal] for calculations,
+ * ensuring accuracy and avoiding floating-point inaccuracies. It supports arithmetic operations
+ * and proper string formatting.
  *
- * @property delegate The underlying [BigDecimal] instance.
+ * The class is [Serializable] using [DollarAmountAsStringSerializer] for seamless conversion
+ * to and from string representations.
+ *
+ * @property delegate The underlying [BigDecimal] instance representing the monetary value.
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @Serializable(with = DollarAmountAsStringSerializer::class)
-actual class DollarAmount private constructor(private val delegate: BigDecimal) {
+actual class DollarAmount {
+
+    private val delegate: BigDecimal
+
+    private constructor(value: BigDecimal) {
+        delegate = value
+    }
     /**
      * Creates a [DollarAmount] from a string value.
-     * @param value The string representation of the dollar amount.
+     *
+     * The input string must conform to the [DOLLAR_AMOUNT_REGEX] pattern,
+     * typically representing a numeric value with an optional decimal part.
+     *
+     * @param value The string representation of the dollar amount (e.g., "10.00", "5", "123.45").
+     * @throws DollarAmountFormatException if the input string is not a valid dollar amount format
+     *                                     or cannot be parsed as a [BigDecimal].
      */
-    actual constructor(value: String) : this(BigDecimal(value))
+    @Throws(DollarAmountFormatException::class)
+    actual constructor(value: String) {
+        requireValidDollarAmount(value)
+        try {
+            delegate = BigDecimal(value)
+        } catch (_: NumberFormatException) {
+            throw DollarAmountFormatException("Invalid dollar amount format: $value")
+        }
+    }
 
     /**
      * Adds another [DollarAmount] to this one.
      * @param other The [DollarAmount] to add.
-     * @return A new [DollarAmount] representing the sum.
+     * @return A new [DollarAmount] representing the sum of the two amounts.
      */
     actual operator fun plus(other: DollarAmount): DollarAmount {
         return DollarAmount(delegate.add(other.delegate))
@@ -40,7 +65,9 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
 
     /**
      * Returns the string representation of this [DollarAmount],
-     * rounded to 2 decimal places using half-even rounding.
+     * rounded to 2 decimal places using half-even rounding ([RoundingMode.HALF_EVEN]).
+     *
+     * For example, a value of `10.456` will be represented as `"10.46"`, and `10` as `"10.00"`.
      */
     actual override fun toString(): String {
         return delegate.setScale(2, RoundingMode.HALF_EVEN).toString()
@@ -50,7 +77,7 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
      * Checks if this [DollarAmount] is equal to another object.
      *
      * Two [DollarAmount] instances are considered equal if their underlying [BigDecimal]
-     * representations are numerically equal (i.e., `compareTo` returns 0).
+     * representations are numerically equal (i.e., `compareTo` returns 0), regardless of their scale.
      * For an object to be equal to a [DollarAmount], it must also be
      * an instance of [DollarAmount].
      *
@@ -62,7 +89,7 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
         if (this === other) return true
         if (other == null || this::class != other::class) return false
         if (other !is DollarAmount) return false
-        return delegate.compareTo(other.delegate) == 0
+        return this.toString() == other.toString()
     }
 
     /**
@@ -70,7 +97,8 @@ actual class DollarAmount private constructor(private val delegate: BigDecimal) 
      *
      * The hash code is calculated based on the underlying [BigDecimal] value after stripping trailing zeros.
      * This ensures that two [DollarAmount] instances considered equal by the [equals] method
-     * (i.e., having numerically equal [BigDecimal] values) will have the same hash code.
+     * (i.e., having numerically equal [BigDecimal] values) will have the same hash code,
+     * promoting correct behavior in hash-based collections.
      *
      * @return The hash code for this dollar amount.
      */

--- a/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.ios.kt
+++ b/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.ios.kt
@@ -73,6 +73,7 @@ actual class DollarAmount {
      * formatted to 2 decimal places using [NSNumberFormatterDecimalStyle].
      *
      * For example, a value representing `10.456` will be formatted as `"10.46"`, and `10` as `"10.00"`.
+     * A zero value will always be positive ("0.00") to ensure consistent behavior among platforms.
      */
     actual override fun toString(): String {
         val numberFormatter = NSNumberFormatter().apply {
@@ -85,15 +86,14 @@ actual class DollarAmount {
 
         val returnString = numberFormatter.stringFromNumber(delegate) ?: delegate.toString()
 
-        // Zero will always be positive to ensure consistent behavior among platforms
         return if (returnString == "-0.00") "0.00" else returnString
     }
 
     /**
      * Checks if this [DollarAmount] is equal to another object.
      *
-     * Two [DollarAmount] instances are considered equal if their underlying [NSDecimalNumber]
-     * representations are numerically equal (i.e., `isEqual` returns `true`).
+     * Two [DollarAmount] instances are considered equal if their canonical string
+     * representations (as returned by [toString]) are equal.
      * For an object to be equal to a [DollarAmount], it must also be an instance of [DollarAmount].
      *
      * @param other The object to compare with.
@@ -108,15 +108,15 @@ actual class DollarAmount {
     }
 
     /**
-     * Returns the hash code of this [DollarAmount].
+     * Returns the hash code for this [DollarAmount].
      *
-     * The hash code is calculated based on the underlying [NSDecimalNumber] value.
-     * This ensures that two [DollarAmount] instances considered equal by the [equals] method
+     * The hash code is calculated based on its canonical string representation (as returned by [toString]),
+     * ensuring that two [DollarAmount] instances considered equal by the [equals] method
      * will have the same hash code, promoting correct behavior in hash-based collections.
      *
-     * @return The hash code.
+     * @return The hash code for this dollar amount.
      */
     actual override fun hashCode(): Int {
-        return delegate.hash().toInt()
+        return toString().hashCode()
     }
 }

--- a/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.ios.kt
+++ b/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.ios.kt
@@ -9,19 +9,43 @@ import platform.Foundation.NSNumberFormatterDecimalStyle
 /**
  * iOS-specific implementation of [DollarAmount].
  *
- * Uses [NSDecimalNumber] for calculations and [NSNumberFormatter] for string conversion.
+ * This class provides a precise representation of monetary values using [NSDecimalNumber] for calculations,
+ * ensuring accuracy and avoiding floating-point inaccuracies. It supports arithmetic operations
+ * and proper string formatting using [NSNumberFormatter].
+ *
+ * The class is [Serializable] using [DollarAmountAsStringSerializer] for seamless conversion
+ * to and from string representations.
  *
  * @property delegate The underlying [NSDecimalNumber] instance.
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @Serializable(with = DollarAmountAsStringSerializer::class)
-actual class DollarAmount private constructor(private val delegate: NSDecimalNumber) {
+actual class DollarAmount {
+    private val delegate: NSDecimalNumber
+
+    private constructor(delegate: NSDecimalNumber) {
+        this.delegate = delegate
+    }
     /**
      * Creates a [DollarAmount] from a string value.
-     * @param value The string representation of the dollar amount.
+     *
+     * The input string must conform to the [DOLLAR_AMOUNT_REGEX] pattern,
+     * typically representing a numeric value with an optional decimal part.
+     *
+     * @param value The string representation of the dollar amount (e.g., "10.00", "5", "123.45").
+     * @throws DollarAmountFormatException if the input string is not a valid dollar amount format
+     *                                     or cannot be parsed as a [NSDecimalNumber].
      */
+    @Throws(DollarAmountFormatException::class)
     @OptIn(ExperimentalForeignApi::class)
-    actual constructor(value: String) : this(NSDecimalNumber(value))
+    actual constructor(value: String) {
+        requireValidDollarAmount(value)
+        try {
+            delegate = NSDecimalNumber(string = value)
+        } catch (_: Throwable) {
+            throw DollarAmountFormatException("Invalid dollar amount format: $value")
+        }
+    }
 
     /**
      * Adds another [DollarAmount] to this one.
@@ -45,35 +69,49 @@ actual class DollarAmount private constructor(private val delegate: NSDecimalNum
 
     /**
      * Returns the string representation of this [DollarAmount],
-     * formatted to 2 decimal places.
+     * formatted to 2 decimal places using [NSNumberFormatterDecimalStyle].
+     *
+     * For example, a value representing `10.456` will be formatted as `"10.46"`, and `10` as `"10.00"`.
      */
     actual override fun toString(): String {
-        val numberFormatter = NSNumberFormatter()
-        numberFormatter.numberStyle = NSNumberFormatterDecimalStyle
-        numberFormatter.minimumFractionDigits = 2.toULong()
-        numberFormatter.maximumFractionDigits = 2.toULong()
+        val numberFormatter = NSNumberFormatter().apply {
+            numberStyle = NSNumberFormatterDecimalStyle
+            usesGroupingSeparator = false
+            minimumFractionDigits = 2.toULong()
+            maximumFractionDigits = 2.toULong()
+        }
 
         return numberFormatter.stringFromNumber(delegate) ?: delegate.toString()
     }
 
     /**
      * Checks if this [DollarAmount] is equal to another object.
+     *
+     * Two [DollarAmount] instances are considered equal if their underlying [NSDecimalNumber]
+     * representations are numerically equal (i.e., `isEqual` returns `true`).
+     * For an object to be equal to a [DollarAmount], it must also be an instance of [DollarAmount].
+     *
      * @param other The object to compare with.
-     * @return `true` if the objects are equal, `false` otherwise.
+     * @return `true` if `other` is a [DollarAmount] representing the same monetary value as this instance,
+     *         `false` otherwise.
      */
     actual override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
         if (other !is DollarAmount) return false
-        return delegate.isEqual(other.delegate)
+        return this.toString() == other.toString()
     }
 
     /**
      * Returns the hash code of this [DollarAmount].
+     *
+     * The hash code is calculated based on the underlying [NSDecimalNumber] value.
+     * This ensures that two [DollarAmount] instances considered equal by the [equals] method
+     * will have the same hash code, promoting correct behavior in hash-based collections.
+     *
      * @return The hash code.
      */
     actual override fun hashCode(): Int {
         return delegate.hash().toInt()
     }
-
 }

--- a/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.ios.kt
+++ b/client/composeApp/src/iosMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.ios.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 import platform.Foundation.NSDecimalNumber
 import platform.Foundation.NSNumberFormatter
 import platform.Foundation.NSNumberFormatterDecimalStyle
+import platform.Foundation.NSNumberFormatterRoundHalfEven
 
 /**
  * iOS-specific implementation of [DollarAmount].
@@ -79,9 +80,13 @@ actual class DollarAmount {
             usesGroupingSeparator = false
             minimumFractionDigits = 2.toULong()
             maximumFractionDigits = 2.toULong()
+            roundingMode = NSNumberFormatterRoundHalfEven
         }
 
-        return numberFormatter.stringFromNumber(delegate) ?: delegate.toString()
+        val returnString = numberFormatter.stringFromNumber(delegate) ?: delegate.toString()
+
+        // Zero will always be positive to ensure consistent behavior among platforms
+        return if (returnString == "-0.00") "0.00" else returnString
     }
 
     /**

--- a/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.wasmJs.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.wasmJs.kt
@@ -89,7 +89,10 @@ actual class DollarAmount {
      * For example, a value representing `10.456` will be formatted as `"10.46"`, and `10` as `"10.00"`.
      */
     actual override fun toString(): String {
-        return delegate.toFixed(2, Big.roundHalfEven)
+        val returnString =  delegate.toFixed(2, Big.roundHalfEven)
+
+        // Zero will always be positive to ensure consistent behavior among platforms
+        return if (returnString == "-0.00") "0.00" else returnString
     }
 
     /**

--- a/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.wasmJs.kt
+++ b/client/composeApp/src/wasmJsMain/kotlin/io/aoriani/ecomm/data/model/DollarAmount.wasmJs.kt
@@ -87,19 +87,19 @@ actual class DollarAmount {
      * rounded to 2 decimal places using the `Big.js` half-even rounding mode ([Big.roundHalfEven]).
      *
      * For example, a value representing `10.456` will be formatted as `"10.46"`, and `10` as `"10.00"`.
+     * A zero value will always be positive ("0.00") to ensure consistent behavior among platforms.
      */
     actual override fun toString(): String {
         val returnString =  delegate.toFixed(2, Big.roundHalfEven)
 
-        // Zero will always be positive to ensure consistent behavior among platforms
         return if (returnString == "-0.00") "0.00" else returnString
     }
 
     /**
      * Checks if this [DollarAmount] is equal to another object.
      *
-     * Two [DollarAmount] instances are considered equal if their underlying `Big.js`
-     * representations are numerically equal (as determined by `Big.eq()`).
+     * Two [DollarAmount] instances are considered equal if their canonical string
+     * representations (as returned by [toString]) are equal.
      * For an object to be equal to a [DollarAmount], it must also be
      * an instance of [DollarAmount].
      *
@@ -117,15 +117,13 @@ actual class DollarAmount {
     /**
      * Returns the hash code for this [DollarAmount].
      *
-     * The hash code is calculated based on the string representation of its underlying `Big.js` value.
-     * This ensures that two [DollarAmount] instances considered equal by the [equals] method
-     * will have the same hash code, promoting correct behavior in hash-based collections.
+     * The hash code is calculated based on the canonical string representation of this dollar amount
+     * (as returned by [toString]), ensuring that two [DollarAmount] instances considered equal by
+     * the [equals] method will have the same hash code, promoting correct behavior in hash-based collections.
      *
      * @return The hash code for this dollar amount.
      */
     actual override fun hashCode(): Int {
-        // The most straightforward way to ensure consistency with an `eq` method
-        // from an external JS library is to base the hashCode on the canonical string representation.
-        return delegate.toString().hashCode()
+        return toString().hashCode()
     }
 }


### PR DESCRIPTION
## Summary

- **Equality & hashing** – Updated to use the canonical string representation (`toString()`) for both `equals` and `hashCode` on iOS, Android, Desktop, and WasmJS.
- **String formatting** – Consistent `"0.00"` for zero values and half‑even rounding on all platforms. `NSNumberFormatterRoundHalfEven` is used for iOS, and `Big.js`/`BigDecimal` handle rounding elsewhere.
- **Input validation** – New `DollarAmountFormatException` and `requireValidDollarAmount(String)` enforce `DOLLAR_AMOUNT_REGEX` across all platforms.
- **Serialization** – `DollarAmount` is now `@Serializable(with = DollarAmountAsStringSerializer::class)`, enabling string‑based JSON handling.
- **Constructors** – All platform constructors now wrap delegate creation in try‑catch blocks to throw `DollarAmountFormatException` on parsing errors.
- **Tests** – Extensive test coverage added for validation, serialization, equality, hashing, and SQLDelight adapters; test cases adjusted for new rounding and zero‑value handling.